### PR TITLE
Adding sudo only where needed

### DIFF
--- a/installeda.sh
+++ b/installeda.sh
@@ -1,6 +1,6 @@
 echo "*****************************  Installing yosys dependancies   ********************************"
-apt update
-apt install build-essential clang bison flex \
+sudo apt update
+sudo apt install build-essential clang bison flex \
 	libreadline-dev gawk tcl-dev libffi-dev git \
 	graphviz xdot pkg-config python3 libboost-system-dev \
 	libboost-python-dev libboost-filesystem-dev zlib1g-dev --assume-yes
@@ -9,7 +9,7 @@ echo "********************** Cloning yosys and will start installation of yosys 
 git clone https://github.com/YosysHQ/yosys.git
 cd yosys
 make
-make install
+sudo make install
 cd
 
 echo "************************* Cloning OpenSTA and will start installation of OpenSTA *****************"
@@ -17,32 +17,32 @@ git clone https://github.com/The-OpenROAD-Project/OpenSTA.git
 cd OpenSTA
 mkdir build
 cd build
-apt install cmake --assume-yes
-apt update -y --assume-yes
-apt install -y swig --assume-yes
+sudo apt install cmake --assume-yes
+sudo apt update -y --assume-yes
+sudo apt install -y swig --assume-yes
 cmake ..
 make
-make install
+sudo make install
 cd 
 
 ##Install Icarus iverilog
 
-apt install -y autoconf gperf make gcc g++ bison flex
+sudo apt install -y autoconf gperf make gcc g++ bison flex
 git clone https://github.com/steveicarus/iverilog.git
 cd iverilog
 chmod 777 autoconf.sh 
 ./autoconf.sh
 ./configure 
 make
-make install
+sudo make install
 cd
 
 echo "****************************************** Installing gtkwave ***********************************"
-apt install gtkwave --assume-yes
+sudo apt install gtkwave --assume-yes
 
 #To install netlist viewer
 cd
-apt install npm --assume-yes
+sudo apt install npm --assume-yes
 git clone https://github.com/nturley/netlistsvg
 cd netlistsvg
 npm install --legacy-peer-deps --assume-yes


### PR DESCRIPTION
This should make it possible to run the installeda.sh without sudo, so that the projects are built in the home directory of the user, not in /root . But at the same time the installeda.sh script can also be run with sudo all together, potentially helping not to have to enter the password several times.